### PR TITLE
fix(sink-fix): Fix sink bug and update dynamo lib for consistency

### DIFF
--- a/serverless-compose.yml
+++ b/serverless-compose.yml
@@ -22,6 +22,7 @@ services:
       sesLogGroupName: ${alerts.SesLogGroupName}
       errorsTopicArn: ${alerts.ErrorsTopicArn}
   connector:
+    dependsOn: compare
     path: src/services/connector
     params:
       mmdlTableName: ${mmdl.TableName}

--- a/src/libs/dynamodb-lib.js
+++ b/src/libs/dynamodb-lib.js
@@ -8,10 +8,12 @@ const { marshall, unmarshall } = require("@aws-sdk/util-dynamodb");
 
 const client = new DynamoDBClient({ region: process.env.region });
 
-export async function putItem(tableName, item) {
+export async function putItem({ tableName, item }) {
   const params = {
     TableName: tableName,
-    Item: marshall(item),
+    Item: marshall(item, {
+      removeUndefinedValues: true,
+    }),
   };
 
   try {
@@ -52,7 +54,7 @@ export async function putItem(tableName, item) {
   }
 }
 
-export async function getItem(tableName, id) {
+export async function getItem({ tableName, id }) {
   const item = (
     await client.send(
       new GetItemCommand({

--- a/src/services/compare/handlers/getMmdlData.js
+++ b/src/services/compare/handlers/getMmdlData.js
@@ -5,7 +5,10 @@ exports.handler = async function (event, context, callback) {
   console.log("Received event:", JSON.stringify(event, null, 2));
   const data = { ...event.Payload };
   try {
-    const mmdlRecord = await getItem(process.env.mmdlTableName, data.id);
+    const mmdlRecord = await getItem({
+      tableName: process.env.mmdlTableName,
+      id: data.id,
+    });
     data.mmdlRecord = mmdlRecord;
 
     const { programType } = getMmdlProgType(mmdlRecord);

--- a/src/services/compare/handlers/initStatus.js
+++ b/src/services/compare/handlers/initStatus.js
@@ -6,10 +6,7 @@ exports.handler = async function (event, context, callback) {
   const data = { iterations: 0, id };
 
   try {
-    await putItem({
-      tableName: process.env.statusTableName,
-      item: data,
-    });
+    await putItem(process.env.statusTableName, data);
   } catch (e) {
     await trackError(e);
   } finally {

--- a/src/services/compare/handlers/seatoolRecordExist.js
+++ b/src/services/compare/handlers/seatoolRecordExist.js
@@ -4,7 +4,10 @@ exports.handler = async function (event, context, callback) {
   console.log("Received event:", JSON.stringify(event, null, 2));
   const data = { ...event.Payload, seatoolExist: false };
   try {
-    const item = await getItem(process.env.seatoolTableName, data.id);
+    const item = await getItem({
+      tableName: process.env.seatoolTableName,
+      id: data.id,
+    });
 
     if (item) {
       data.seatoolExist = true;

--- a/src/services/compare/handlers/workflowStarter.js
+++ b/src/services/compare/handlers/workflowStarter.js
@@ -10,7 +10,10 @@ exports.handler = async function (event, context, callback) {
   const id = event.Records[0].dynamodb.Keys.id.S;
 
   /* Retrieving the record from the DynamoDB table. */
-  const mmdlRecord = await getItem(process.env.mmdlTableName, id);
+  const mmdlRecord = await getItem({
+    tableName: process.env.mmdlTableName,
+    id,
+  });
 
   /* A function that returns an object with the following properties:
   - mmdlSigned: boolean


### PR DESCRIPTION
## Purpose

Fix bug preventing items from connector sinking with the dynamo tables. 

#### Linked Issues to Close

N/A

## Approach

Dynamo getItem helper was taking in two params instead of a single object. This was causing errors when attempting to sink items from the connector. Updated to be consistent across project and helper functions. Also adding compare as a dependsOn of the connector to ensure the service is established before events begin streaming. Additionally adding options to marshal function to remove any undefined values from the item passed.
