### PR TITLE
fix(executor): Add step function execution stopping step in destroy script

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -124,7 +124,7 @@ yargs(process.argv.slice(2))
           Value: `${process.env.PROJECT}`,
         },
       ];
-      // is we are destroying the entire stack or just the 'compare' stack - stop all sf executions on compare service before destroying stack
+      // if we are destroying the entire stack or just the 'compare' stack - stop all sf executions on the compare service before destroying stack
       if (!options.service || options.service === "compare") {
         await runner.run_command_and_output(
           `stop step function executions`,

--- a/src/run.ts
+++ b/src/run.ts
@@ -124,6 +124,14 @@ yargs(process.argv.slice(2))
           Value: `${process.env.PROJECT}`,
         },
       ];
+      // is we are destroying the entire stack or just the 'compare' stack - stop all sf executions on compare service before destroying stack
+      if (!options.service || options.service === "compare") {
+        await runner.run_command_and_output(
+          `stop step function executions`,
+          ["sls", "compare", "stop-executions", "--stage", options.stage],
+          "."
+        );
+      }
       if (options.service) {
         filters.push({
           Key: "SERVICE",

--- a/src/services/compare/serverless.yml
+++ b/src/services/compare/serverless.yml
@@ -11,6 +11,7 @@ plugins:
   - "@stratiformdigital/serverless-online"
   - "@stratiformdigital/serverless-iam-helper"
   - serverless-step-functions
+  - serverless-plugin-scripts
   - serverless-esbuild
 
 provider:
@@ -92,6 +93,17 @@ custom:
       - val
       - production
   secretId: ${self:custom.project}/${sls:stage}/alerts
+  scripts:
+    commands:
+      stop-executions: |
+        aws stepfunctions list-executions \
+        --state-machine-arn arn:aws:states:${self:provider.region}:${aws:accountId}:stateMachine:${self:service}-${sls:stage}-compare-alerting \
+        --status-filter RUNNING \
+        --query "executions[*].{executionArn:executionArn}" \
+        --output text | \
+        xargs -I {} aws stepfunctions stop-execution \
+        --execution-arn {} >> out.t
+        rm out.t
 
 functions:
   workflowStarter:


### PR DESCRIPTION
## Purpose

Step function machines can not be destroyed if they have executions running. This change adds a step to the destroy script to stop all running executions of the compare step function machine if the entire stage or just the compare service is being destroyed.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-22836

## Approach

this will allow the step machine to be detroyed without having to manually stop all step function executions.

## Assorted Notes/Considerations

We should no longer need to manually stop step function executions before deleting/destroying a branch.
