### PR TITLE
feat(waiver-id): Use waiver id and remove compare steps (temp)

### DIFF
--- a/src/libs/dynamodb-lib.ts
+++ b/src/libs/dynamodb-lib.ts
@@ -96,15 +96,16 @@ const ddbDocClient = DynamoDBDocumentClient.from(client, {
   marshallOptions,
 });
 
-export const scanTable = async (tableName) => {
+export const scanTable = async (tableName: string) => {
   const params = {
     TableName: tableName,
   };
   try {
     const raw = await ddbDocClient.send(new ScanCommand(params));
-    const data = raw.Items.map(unmarshall);
+    const data = raw.Items?.map(unmarshall as any);
     return data;
   } catch (err) {
     console.log("Error", err);
+    return;
   }
 };

--- a/src/services/compare/handlers/getMmdlData.ts
+++ b/src/services/compare/handlers/getMmdlData.ts
@@ -15,6 +15,7 @@ exports.handler = async function (
       id: data.id,
     });
     data.mmdlRecord = mmdlRecord;
+    data.transmittalNumber = mmdlRecord?.transmittalNumber;
 
     const { programType } = getMmdlProgType(mmdlRecord as MmdlRecord);
     const sigInfo = getMmdlSigInfo(mmdlRecord as MmdlRecord);

--- a/src/services/compare/handlers/interfaces.ts
+++ b/src/services/compare/handlers/interfaces.ts
@@ -4,4 +4,5 @@ export interface MmdlRecord {
   hhs_transNbr: { FIELD_PROGRAM_TYPE_CODE: string };
   stMedDirSgnDt: { FIELD_VALUE: any };
   id: any;
+  transmittalNumber: string;
 }

--- a/src/services/compare/handlers/seatoolRecordExist.ts
+++ b/src/services/compare/handlers/seatoolRecordExist.ts
@@ -10,14 +10,16 @@ exports.handler = async function (
   try {
     const item = await getItem({
       tableName: process.env.seatoolTableName,
-      id: data.id,
+      id: data.transmittalNumber, // we use the transmittal number here
     });
 
     if (item) {
       data.seatoolExist = true;
       data.seatoolRecord = item;
     } else {
-      console.log(`No Seatool record found for mmdl record: ${data.id}`);
+      console.log(
+        `No Seatool record found for mmdl record id: ${data.id}, tranmittalNumber: ${data.transmittalNumber}`
+      );
     }
   } catch (e) {
     await trackError(e);

--- a/src/services/compare/serverless.yml
+++ b/src/services/compare/serverless.yml
@@ -70,18 +70,22 @@ provider:
 params:
   master:
     initialWaitSec: 172800 # 2 days
+    tempWaitSec: 172800 # 2 days
     signedSinceChoiceSec: 345600 # 4 days
     recordAgeChoiceSec: 21686400 # 251 days
   val:
     initialWaitSec: 172800
+    tempWaitSec: 172800
     signedSinceChoiceSec: 345600
     recordAgeChoiceSec: 21686400
   production:
     initialWaitSec: 172800
+    tempWaitSec: 172800
     signedSinceChoiceSec: 345600
     recordAgeChoiceSec: 21686400
   default:
     initialWaitSec: 2
+    tempWaitSec: 43200 # 12 hours
     signedSinceChoiceSec: 3
     recordAgeChoiceSec: 21686400 # 251 days
 
@@ -230,7 +234,8 @@ stepFunctions:
             Choices:
               - Variable: $.seatoolExist
                 BooleanEquals: true
-                Next: CompareTask
+                Next: UpdateStatusTask # for now we are skipping the compare task
+                # Next: CompareTask
               - Variable: $.seatoolExist
                 BooleanEquals: false
                 Next: SignedSinceChoice
@@ -262,7 +267,7 @@ stepFunctions:
             Default: TempWait
           TempWait:
             Type: Wait
-            Seconds: 43200
+            Seconds: ${param:tempWaitSec}
             Next: InitialWait
           LastLoopAMatchChoice:
             Type: Choice
@@ -274,28 +279,28 @@ stepFunctions:
                     BooleanEquals: true
                 Next: SuccessState
             Default: FailState
-          CompareTask:
-            Type: Task
-            Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-compare"
-            Parameters:
-              Payload.$: $
-            Next: RecordsMatchChoice
-          RecordsMatchChoice:
-            Type: Choice
-            Choices:
-              - Variable: $.match
-                BooleanEquals: true
-                Next: UpdateStatusTask
-              - Variable: $.match
-                BooleanEquals: false
-                Next: SendNotMatchTask
-            Default: SendNotMatchTask
-          SendNotMatchTask:
-            Type: Task
-            Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-sendNoMatchAlert"
-            Parameters:
-              Payload.$: $
-            Next: UpdateStatusTask
+          # CompareTask:
+          #   Type: Task
+          #   Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-compare"
+          #   Parameters:
+          #     Payload.$: $
+          #   Next: RecordsMatchChoice
+          # RecordsMatchChoice:
+          #   Type: Choice
+          #   Choices:
+          #     - Variable: $.match
+          #       BooleanEquals: true
+          #       Next: UpdateStatusTask
+          #     - Variable: $.match
+          #       BooleanEquals: false
+          #       Next: SendNotMatchTask
+          #   Default: SendNotMatchTask
+          # SendNotMatchTask:
+          #   Type: Task
+          #   Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-sendNoMatchAlert"
+          #   Parameters:
+          #     Payload.$: $
+          #   Next: UpdateStatusTask
           UpdateStatusTask:
             Type: Task
             Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-updateStatus"


### PR DESCRIPTION
## Purpose

This change uses the waiver id, state, and program code to create the immutable key that represents an mmdl record

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-22821

(This will not close the issue) 

## Approach

Since transmittal id's can be changed in mmdl we need to use the waiver id, which is exclusive to each record as a key to store the mmdl record data. This way if a user changes the transmittal number it will not create a new comparison record, but will instead update the existing waiver.

Additionally we are updating the transmittal number to always be stored as an upper case string to match its potential companion record in seatool.

## Assorted Notes/Considerations

This change also removed (temporarily comments out) the comparison steps to check for a data match between records. 
