### PR TITLE
feat(mmdl-schema-update): Update to use new mmdl stream schema and latest submitted status

### DIFF
--- a/src/libs/types/interfaces.ts
+++ b/src/libs/types/interfaces.ts
@@ -1,0 +1,84 @@
+export interface MmdlRecord {
+  mac179_transNbr?: { FIELD_PROGRAM_TYPE_CODE: string };
+  chp179_transNbr?: { FIELD_PROGRAM_TYPE_CODE: string };
+  hhs_transNbr?: { FIELD_PROGRAM_TYPE_CODE: string };
+  stMedDirSgnDt?: { FIELD_VALUE: any };
+  statuses: ApplicationWorkflowStatus[];
+  id: any;
+  transmittalNumber: string;
+}
+
+export interface MmdlStreamRecord {
+  FORM_FIELDS: FormFields;
+  APPLICATION_WORKFLOW_STATUSES: ApplicationWorkflowStatus[];
+}
+
+export interface FormFields {
+  [key: string]: MmdlFormField;
+}
+
+export interface MmdlFormField {
+  FIELD_NAME: string;
+  FIELD_DESCRIPTION: string;
+  FIELD_VALUE: string;
+  FIELD_MAPPING_DATA_TYPE: string;
+  FIELD_CHANGE_TYPE_CODE: string;
+  FIELD_MAPPING_NOTE_TEXT: any;
+  FIELD_PROGRAM_TYPE_CODE: string;
+  REVISION_ID: number;
+  REVISION_TITLE_DESCRIPTION: any;
+  REVISION_REQUEST_TYPE_CODE: string;
+  REVISION_APPROVED_EFFECTIVE_DATE: number;
+  REVISION_VERSION_ID: number;
+  REVISION_VERSION_WAIVER_DESCIPTION: string;
+  REVISION_VERSION_MODEL_TYPE_CODE: string;
+  WAIVER_TYPE_CODE: string;
+  WAIVER_REVISION_TITLE_TEXT: any;
+  WAIVER_REVISION_APPROVED_DATE: number;
+  WAIVER_REVISION_EXPIRATION_DATE: number;
+  WAVIER_REVISION_CLOCK_START_DATE: number;
+}
+
+/* APLCTN_[LAST_]LIFE_CYC_STUS_CD */
+
+/*
+  C_PLACEHOLDER   = -3
+  C_INACTIVE      = -2
+  C_INCIPIENT     = -1 - DRAFT
+  C_INCOMPLETE    =  0
+  C_PENDING       =  1 - SUBMITTED
+  C_UNSUBMITTED   =  2
+  C_WITHDRAWN     =  3
+  C_REJECTED      =  4
+  C_APPROVED      =  5
+  C_EXPIRED       =  6
+  C_TERMINATED    =  7
+  C_WAITING_RAI   =  9
+  C_WAITING_IRAI  =  10
+*/
+
+export interface ApplicationWorkflowStatus {
+  APLCTN_WRKFLW_STUS_ID: number;
+  PLAN_WVR_RVSN_VRSN_ID: number;
+  PLAN_WVR_RVSN_ID: number;
+  APLCTN_LIFE_CYC_STUS_CD: number;
+  APLCTN_LAST_LIFE_CYC_STUS_CD?: number;
+  APLCTN_WRKFLW_STUS_TS: number;
+  PLAN_WVR_SRC_TYPE_CD: string;
+  PLAN_WVR_SRC_TYPE_ID: number;
+  APLCTN_LIFE_CYC_STUS_TYPE_CD: number;
+  REPLICA_TIMESTAMP: number;
+  REPLICA_ID: number;
+}
+
+export interface MmdlSeatoolCompareData {
+  mmdlSigned: boolean;
+  secSinceMmdlSigned?: number;
+  mmdlSigDate?: Date;
+  status?: number;
+  lastStatus?: number;
+  mmdlRecord: MmdlRecord;
+  id: string;
+  transmittalNumber: string;
+  programType?: string;
+}

--- a/src/services/compare/handlers/getMmdlData.ts
+++ b/src/services/compare/handlers/getMmdlData.ts
@@ -20,10 +20,13 @@ exports.handler = async function (
     const { programType } = getMmdlProgType(mmdlRecord as Types.MmdlRecord);
     const sigInfo = getMmdlSigInfo(mmdlRecord as Types.MmdlRecord);
 
+    const isStatusSubmitted = sigInfo.status === 1;
+
     data.programType = programType;
     data.secSinceMmdlSigned = sigInfo.secSinceMmdlSigned;
     data.mmdlSigned = sigInfo.mmdlSigned;
     data.mmdlSigDate = sigInfo.mmdlSigDate;
+    data.isStatusSubmitted = isStatusSubmitted;
   } catch (e) {
     await trackError(e);
   } finally {

--- a/src/services/compare/handlers/getMmdlData.ts
+++ b/src/services/compare/handlers/getMmdlData.ts
@@ -1,6 +1,9 @@
 import { getItem, trackError } from "../../../libs";
 import { getMmdlProgType, getMmdlSigInfo } from "./utils/getMmdlInfoFromRecord";
-import { MmdlRecord } from "./interfaces";
+import {
+  MmdlRecord,
+  MmdlSeatoolCompareData,
+} from "../../../libs/types/interfaces";
 
 exports.handler = async function (
   event: { Payload: any },
@@ -8,13 +11,13 @@ exports.handler = async function (
   callback: Function
 ) {
   console.log("Received event:", JSON.stringify(event, null, 2));
-  const data = { ...event.Payload };
+  const data: MmdlSeatoolCompareData = { ...event.Payload };
   try {
     const mmdlRecord = await getItem({
       tableName: process.env.mmdlTableName,
       id: data.id,
     });
-    data.mmdlRecord = mmdlRecord;
+    data.mmdlRecord = mmdlRecord as MmdlRecord;
     data.transmittalNumber = mmdlRecord?.transmittalNumber;
 
     const { programType } = getMmdlProgType(mmdlRecord as MmdlRecord);

--- a/src/services/compare/handlers/getMmdlData.ts
+++ b/src/services/compare/handlers/getMmdlData.ts
@@ -1,9 +1,6 @@
 import { getItem, trackError } from "../../../libs";
 import { getMmdlProgType, getMmdlSigInfo } from "./utils/getMmdlInfoFromRecord";
-import {
-  MmdlRecord,
-  MmdlSeatoolCompareData,
-} from "../../../libs/types/interfaces";
+import * as Types from "../../../types";
 
 exports.handler = async function (
   event: { Payload: any },
@@ -11,17 +8,17 @@ exports.handler = async function (
   callback: Function
 ) {
   console.log("Received event:", JSON.stringify(event, null, 2));
-  const data: MmdlSeatoolCompareData = { ...event.Payload };
+  const data: Types.MmdlSeatoolCompareData = { ...event.Payload };
   try {
     const mmdlRecord = await getItem({
       tableName: process.env.mmdlTableName,
       id: data.id,
     });
-    data.mmdlRecord = mmdlRecord as MmdlRecord;
+    data.mmdlRecord = mmdlRecord as Types.MmdlRecord;
     data.transmittalNumber = mmdlRecord?.transmittalNumber;
 
-    const { programType } = getMmdlProgType(mmdlRecord as MmdlRecord);
-    const sigInfo = getMmdlSigInfo(mmdlRecord as MmdlRecord);
+    const { programType } = getMmdlProgType(mmdlRecord as Types.MmdlRecord);
+    const sigInfo = getMmdlSigInfo(mmdlRecord as Types.MmdlRecord);
 
     data.programType = programType;
     data.secSinceMmdlSigned = sigInfo.secSinceMmdlSigned;

--- a/src/services/compare/handlers/interfaces.ts
+++ b/src/services/compare/handlers/interfaces.ts
@@ -1,8 +1,0 @@
-export interface MmdlRecord {
-  mac179_transNbr: { FIELD_PROGRAM_TYPE_CODE: string };
-  chp179_transNbr: { FIELD_PROGRAM_TYPE_CODE: string };
-  hhs_transNbr: { FIELD_PROGRAM_TYPE_CODE: string };
-  stMedDirSgnDt: { FIELD_VALUE: any };
-  id: any;
-  transmittalNumber: string;
-}

--- a/src/services/compare/handlers/sendReport.ts
+++ b/src/services/compare/handlers/sendReport.ts
@@ -11,6 +11,7 @@ function formatReportData(data: Types.MmdlReportData[]) {
       "Seatool Record Exist": i.seatoolExist,
       "Seatool Signed Date": i.seatoolSigDate || "N/A",
       "Records Match": i.match || false,
+      "Submitted Status": i.isStatusSubmitted || false,
     };
   });
 }

--- a/src/services/compare/handlers/sendReport.ts
+++ b/src/services/compare/handlers/sendReport.ts
@@ -1,21 +1,7 @@
-import {
-  sendAttachment,
-  trackError,
-  scanTable,
-  getCsvFromJson,
-} from "../../../libs";
+import * as Libs from "../../../libs";
+import * as Types from "../../../types";
 
-interface Data {
-  id: string;
-  iterations: number;
-  programType: string;
-  mmdlSigDate: string;
-  seatoolExist: boolean;
-  seatoolSigDate?: string;
-  match?: boolean;
-}
-
-function formatReportData(data: Data[]) {
+function formatReportData(data: Types.MmdlReportData[]) {
   return data.map((i) => {
     return {
       "Transmittal ID": i.id,
@@ -60,14 +46,18 @@ exports.handler = async function (event: { recipient: string }) {
     throw 'You must manually provide a recipient email in the event to send a report. ex. {"recipient": "user@example.com"}';
   }
 
+  if (!process.env.statusTable) {
+    throw "process.env.statusTable needs to be defined.";
+  }
+
   try {
-    const data = await scanTable(process.env.statusTable);
-    const reportDataJson = formatReportData(data as Data[]);
-    const csv = getCsvFromJson(reportDataJson);
+    const data = await Libs.scanTable(process.env.statusTable);
+    const reportDataJson = formatReportData(data as Types.MmdlReportData[]);
+    const csv = Libs.getCsvFromJson(reportDataJson);
     const mailOptions = getMailOptionsWithAttachment(recipientEmail, csv);
 
-    await sendAttachment(mailOptions);
+    await Libs.sendAttachment(mailOptions);
   } catch (e) {
-    await trackError(e);
+    await Libs.trackError(e);
   }
 };

--- a/src/services/compare/handlers/utils/getMmdlInfoFromRecord.ts
+++ b/src/services/compare/handlers/utils/getMmdlInfoFromRecord.ts
@@ -1,5 +1,13 @@
 import { has } from "lodash";
+import { MmdlRecord } from "../../../../libs/types/interfaces";
 
+interface MmdlSigInfo {
+  secSinceMmdlSigned?: number;
+  mmdlSigned: boolean;
+  mmdlSigDate?: Date;
+  status?: number;
+  lastStatus?: number;
+}
 /**
  * It takes a MMDL record and returns an object with information about when it was signed
  * @param mmdlRecord - MMDL record
@@ -8,21 +16,14 @@ import { has } from "lodash";
  *   secSinceMmdlSigned: number
  *   mmdlSigDate: string
  */
-export function getMmdlSigInfo(mmdlRecord: {
-  stMedDirSgnDt: { FIELD_VALUE: any };
-  id: any;
-}) {
-  const result: {
-    mmdlSigned: boolean;
-    secSinceMmdlSigned?: number;
-    mmdlSigDate?: Date;
-  } = {
+export function getMmdlSigInfo(mmdlRecord: MmdlRecord): MmdlSigInfo {
+  let result: MmdlSigInfo = {
     mmdlSigned: false,
   };
 
   /* Checking to see if the record has been signed. */
   if (has(mmdlRecord, ["stMedDirSgnDt", "FIELD_VALUE"])) {
-    const dateSigned = mmdlRecord.stMedDirSgnDt.FIELD_VALUE;
+    const dateSigned = mmdlRecord.stMedDirSgnDt?.FIELD_VALUE;
 
     /* Calculating the difference between the current date and the date MMDL was signed. */
     const today = new Date().getTime();
@@ -34,10 +35,20 @@ export function getMmdlSigInfo(mmdlRecord: {
       throw `Signed date is future date for MMDL record: ${mmdlRecord.id}`;
     }
 
+    const statuses = mmdlRecord.statuses.sort(
+      (a, b) => b.APLCTN_LIFE_CYC_STUS_CD - a.APLCTN_LIFE_CYC_STUS_CD
+    );
+
+    // we add a default here so there is allways a number value
+    const status = statuses[0].APLCTN_LIFE_CYC_STUS_CD ?? 99;
+    const lastStatus = statuses[1].APLCTN_LAST_LIFE_CYC_STUS_CD ?? 99;
+
     /* Returning the difference between the current date and the date MMDL was signed. */
     result.secSinceMmdlSigned = Math.floor(diffInSec);
     result.mmdlSigned = true;
     result.mmdlSigDate = dateSigned;
+    result.status = status;
+    result.lastStatus = lastStatus;
   }
   return result;
 }
@@ -46,11 +57,9 @@ export function getMmdlSigInfo(mmdlRecord: {
  * It takes a record from the MMDL database and returns the program type
  * @param mmdlRecord - the record from the MMDL table
  */
-export function getMmdlProgType(mmdlRecord: {
-  mac179_transNbr: { FIELD_PROGRAM_TYPE_CODE: string };
-  chp179_transNbr: { FIELD_PROGRAM_TYPE_CODE: string };
-  hhs_transNbr: { FIELD_PROGRAM_TYPE_CODE: string };
-}) {
+export function getMmdlProgType(mmdlRecord: MmdlRecord): {
+  programType?: string;
+} {
   const result: {
     programType?: string;
   } = {};
@@ -58,13 +67,13 @@ export function getMmdlProgType(mmdlRecord: {
   /* Getting the program type code for the record. one and only of these will exists */
   if (has(mmdlRecord, ["mac179_transNbr", "FIELD_PROGRAM_TYPE_CODE"])) {
     result.programType =
-      mmdlRecord.mac179_transNbr.FIELD_PROGRAM_TYPE_CODE || "MAC";
+      mmdlRecord.mac179_transNbr?.FIELD_PROGRAM_TYPE_CODE || "MAC";
   } else if (has(mmdlRecord, ["chp179_transNbr", "FIELD_PROGRAM_TYPE_CODE"])) {
     result.programType =
-      mmdlRecord.chp179_transNbr.FIELD_PROGRAM_TYPE_CODE || "CHP";
+      mmdlRecord.chp179_transNbr?.FIELD_PROGRAM_TYPE_CODE || "CHP";
   } else if (has(mmdlRecord, ["hhs_transNbr", "FIELD_PROGRAM_TYPE_CODE"])) {
     result.programType =
-      mmdlRecord.hhs_transNbr.FIELD_PROGRAM_TYPE_CODE || "HHS";
+      mmdlRecord.hhs_transNbr?.FIELD_PROGRAM_TYPE_CODE || "HHS";
   }
   return result;
 }

--- a/src/services/compare/handlers/utils/getMmdlInfoFromRecord.ts
+++ b/src/services/compare/handlers/utils/getMmdlInfoFromRecord.ts
@@ -1,13 +1,5 @@
 import { has } from "lodash";
-import { MmdlRecord } from "../../../../libs/types/interfaces";
-
-interface MmdlSigInfo {
-  secSinceMmdlSigned?: number;
-  mmdlSigned: boolean;
-  mmdlSigDate?: Date;
-  status?: number;
-  lastStatus?: number;
-}
+import * as Types from "../../../../types";
 /**
  * It takes a MMDL record and returns an object with information about when it was signed
  * @param mmdlRecord - MMDL record
@@ -16,8 +8,10 @@ interface MmdlSigInfo {
  *   secSinceMmdlSigned: number
  *   mmdlSigDate: string
  */
-export function getMmdlSigInfo(mmdlRecord: MmdlRecord): MmdlSigInfo {
-  let result: MmdlSigInfo = {
+export function getMmdlSigInfo(
+  mmdlRecord: Types.MmdlRecord
+): Types.MmdlSigInfo {
+  let result: Types.MmdlSigInfo = {
     mmdlSigned: false,
   };
 
@@ -57,7 +51,7 @@ export function getMmdlSigInfo(mmdlRecord: MmdlRecord): MmdlSigInfo {
  * It takes a record from the MMDL database and returns the program type
  * @param mmdlRecord - the record from the MMDL table
  */
-export function getMmdlProgType(mmdlRecord: MmdlRecord): {
+export function getMmdlProgType(mmdlRecord: Types.MmdlRecord): {
   programType?: string;
 } {
   const result: {

--- a/src/services/compare/handlers/workflowStarter.ts
+++ b/src/services/compare/handlers/workflowStarter.ts
@@ -1,7 +1,7 @@
 import { SFNClient, StartExecutionCommand } from "@aws-sdk/client-sfn";
 import { getItem, trackError } from "../../../libs";
 import { getMmdlSigInfo } from "./utils/getMmdlInfoFromRecord";
-import { MmdlRecord } from "./interfaces";
+import { MmdlRecord } from "../../../libs/types/interfaces";
 
 /* This is the Lambda function that is triggered by the DynamoDB stream. It is responsible for starting
 the Step Function execution. */

--- a/src/services/compare/handlers/workflowStarter.ts
+++ b/src/services/compare/handlers/workflowStarter.ts
@@ -1,7 +1,7 @@
 import { SFNClient, StartExecutionCommand } from "@aws-sdk/client-sfn";
 import { getItem, trackError } from "../../../libs";
 import { getMmdlSigInfo } from "./utils/getMmdlInfoFromRecord";
-import { MmdlRecord } from "../../../libs/types/interfaces";
+import * as Types from "../../../types";
 
 /* This is the Lambda function that is triggered by the DynamoDB stream. It is responsible for starting
 the Step Function execution. */
@@ -21,7 +21,7 @@ exports.handler = async function (event: {
   /* A function that returns an object with the following properties:
   - mmdlSigned: boolean
   - secSinceMmdlSigned?: number */
-  const sigInfo = getMmdlSigInfo(mmdlRecord as MmdlRecord);
+  const sigInfo = getMmdlSigInfo(mmdlRecord as Types.MmdlRecord);
 
   /* Checking if the mmdl was signed within the last 250 days. */
   if (

--- a/src/services/compare/serverless.yml
+++ b/src/services/compare/serverless.yml
@@ -220,7 +220,17 @@ stepFunctions:
             Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-getMmdlData"
             Parameters:
               Payload.$: $
-            Next: DoesSeatoolRecordExistTask
+            Next: StatusSubmittedChoice
+          StatusSubmittedChoice:
+            Type: Choice
+            Choices:
+              - Variable: $.isStatusSubmitted
+                BooleanEquals: true
+                Next: DoesSeatoolRecordExistTask
+              - Variable: $.isStatusSubmitted
+                BooleanEquals: false
+                Next: UpdateStatusTask
+            Default: UpdateStatusTask
           DoesSeatoolRecordExistTask:
             Type: Task
             Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-seatoolRecordExist"

--- a/src/services/connector/handlers/sinkMmdlData.ts
+++ b/src/services/connector/handlers/sinkMmdlData.ts
@@ -1,5 +1,5 @@
 import * as dynamodb from "../../../libs/dynamodb-lib";
-import { MmdlRecord, MmdlStreamRecord } from "../../../libs/types/interfaces";
+import * as Types from "../../../types";
 
 async function myHandler(
   event: { value: string; key: string },
@@ -14,10 +14,10 @@ async function myHandler(
   }
 
   try {
-    const recordKeyObject = JSON.parse(event.key);
-    const recordValueObject = JSON.parse(event.value) as MmdlStreamRecord;
+    const recordKeyObject = JSON.parse(event.key) as Types.MmdlRecordKeyObject;
+    const recordValueObject = JSON.parse(event.value) as Types.MmdlStreamRecord;
 
-    const id = `${recordKeyObject.STATE_CODE}-${recordKeyObject.WAIVER_ID}-${recordKeyObject.PROGRAM_TYPE_CODE}`;
+    const id = `${recordKeyObject.STATE_CODE}-${recordKeyObject.AGGREGATED_FORM_FIELDS_WAIVER_ID}-${recordKeyObject.PROGRAM_TYPE_CODE}`;
 
     // Typically the PROGRAM_TYPE_CODE will match this _transNbr key
     //   MAC: "mac179_transNbr",
@@ -65,7 +65,7 @@ async function myHandler(
       return;
     }
 
-    const item: MmdlRecord = {
+    const item: Types.MmdlRecord = {
       id,
       transmittalNumber: transmittalNumber.trim().toUpperCase(), // remove empty strings and upper case
       ...recordValueObject.FORM_FIELDS,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from "./mmdl";

--- a/src/types/mmdl/index.ts
+++ b/src/types/mmdl/index.ts
@@ -1,0 +1,1 @@
+export * from "./interfaces";

--- a/src/types/mmdl/interfaces.ts
+++ b/src/types/mmdl/interfaces.ts
@@ -13,7 +13,7 @@ export interface MmdlStreamRecord {
   APPLICATION_WORKFLOW_STATUSES: ApplicationWorkflowStatus[];
 }
 
-export interface FormFields {
+interface FormFields {
   [key: string]: MmdlFormField;
 }
 
@@ -57,7 +57,7 @@ export interface MmdlFormField {
   C_WAITING_IRAI  =  10
 */
 
-export interface ApplicationWorkflowStatus {
+interface ApplicationWorkflowStatus {
   APLCTN_WRKFLW_STUS_ID: number;
   PLAN_WVR_RVSN_VRSN_ID: number;
   PLAN_WVR_RVSN_ID: number;
@@ -81,4 +81,29 @@ export interface MmdlSeatoolCompareData {
   id: string;
   transmittalNumber: string;
   programType?: string;
+}
+
+export interface MmdlRecordKeyObject {
+  AGGREGATED_FORM_FIELDS_WAIVER_ID: number;
+  STATE_CODE: string;
+  GROUP_CODE: string;
+  PROGRAM_TYPE_CODE: string;
+}
+
+export interface MmdlSigInfo {
+  secSinceMmdlSigned?: number;
+  mmdlSigned: boolean;
+  mmdlSigDate?: Date;
+  status?: number;
+  lastStatus?: number;
+}
+
+export interface MmdlReportData {
+  id: string;
+  iterations: number;
+  programType: string;
+  mmdlSigDate: string;
+  seatoolExist: boolean;
+  seatoolSigDate?: string;
+  match?: boolean;
 }

--- a/src/types/mmdl/interfaces.ts
+++ b/src/types/mmdl/interfaces.ts
@@ -81,6 +81,7 @@ export interface MmdlSeatoolCompareData {
   id: string;
   transmittalNumber: string;
   programType?: string;
+  isStatusSubmitted?: boolean;
 }
 
 export interface MmdlRecordKeyObject {
@@ -106,4 +107,5 @@ export interface MmdlReportData {
   seatoolExist: boolean;
   seatoolSigDate?: string;
   match?: boolean;
+  isStatusSubmitted?: boolean;
 }


### PR DESCRIPTION
## Purpose

Updating the mmdl compare feature to include the new data schema and switch on mmdl record status.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-22821

## Approach

Updated the mmdl sink lambda to use new data from bigmac, now included form fields and status array. 
Updated types for type declarations to match new schema. 
Added new choice in sf machine to only allow submitted records to alert.


## Assorted Notes/Considerations/Learning

there are still questions around clock start data and last status. i have added those into the sf data objects for use once those requirements are defined. 