### PR TITLE
fix(StopExecutions): Add custom resource to stop executions to compare services

### DIFF
--- a/src/services/compare-appian/serverless.yml
+++ b/src/services/compare-appian/serverless.yml
@@ -190,6 +190,10 @@ resources:
       Type: AWS::Logs::LogGroup
       Properties:
         LogGroupName: /aws/vendedlogs/states/${self:service}-${sls:stage}-alert
+    StopExecutions:
+      Type: Custom::StopExecutions
+      Properties:
+        ServiceToken: !GetAtt StopExecutionsLambdaFunction.Arn
 
 stepFunctions:
   stateMachines:

--- a/src/services/compare/serverless.yml
+++ b/src/services/compare/serverless.yml
@@ -189,6 +189,10 @@ resources:
       Type: AWS::Logs::LogGroup
       Properties:
         LogGroupName: /aws/vendedlogs/states/${self:service}-${sls:stage}-alert
+    StopExecutions:
+      Type: Custom::StopExecutions
+      Properties:
+        ServiceToken: !GetAtt StopExecutionsLambdaFunction.Arn
 
 stepFunctions:
   stateMachines:


### PR DESCRIPTION
## Purpose

Add custom resource to stop executions to compare services

#### Linked Issues to Close

N/A

## Approach

Adds custom resource to compare and appian-compare services to invoke the stopExecutions lambdas in the respective services on stack destroy.

## Assorted Notes/Considerations/Learning

N/A
