### PR TITLE
feat(sort key - delete Item): Add sort key and delete seatool func

### DIFF
--- a/src/libs/dynamodb-lib.ts
+++ b/src/libs/dynamodb-lib.ts
@@ -4,6 +4,8 @@ import {
   GetItemCommand,
   ScanCommand,
   GetItemCommandInput,
+  DeleteItemCommand,
+  DeleteItemCommandInput,
 } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import { sendMetricData } from "./cloudwatch-lib";
@@ -110,3 +112,26 @@ export const scanTable = async (tableName: string) => {
     return;
   }
 };
+
+export async function deleteItem({
+  tableName,
+  key,
+}: {
+  tableName: string;
+  key: {
+    [key: string]: NativeAttributeValue;
+  };
+}) {
+  try {
+    const deleteItemCommandInput: DeleteItemCommandInput = {
+      TableName: tableName,
+      Key: marshall(key),
+    };
+
+    console.log("DELETING ITEM:", deleteItemCommandInput);
+
+    await client.send(new DeleteItemCommand(deleteItemCommandInput));
+  } catch (error) {
+    console.log("ERROR Deleting Item: ", error);
+  }
+}

--- a/src/libs/dynamodb-lib.ts
+++ b/src/libs/dynamodb-lib.ts
@@ -3,10 +3,15 @@ import {
   PutItemCommand,
   GetItemCommand,
   ScanCommand,
+  GetItemCommandInput,
 } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import { sendMetricData } from "./cloudwatch-lib";
-import { marshall, unmarshall } from "@aws-sdk/util-dynamodb";
+import {
+  marshall,
+  NativeAttributeValue,
+  unmarshall,
+} from "@aws-sdk/util-dynamodb";
 
 const client = new DynamoDBClient({ region: process.env.region });
 
@@ -63,23 +68,19 @@ export async function putItem({
 
 export async function getItem({
   tableName,
-  id,
+  key,
 }: {
-  tableName: string | undefined;
-  id: string;
+  tableName: string;
+  key: {
+    [key: string]: NativeAttributeValue;
+  };
 }) {
-  const item = (
-    await client.send(
-      new GetItemCommand({
-        TableName: tableName,
-        Key: {
-          id: {
-            S: id,
-          },
-        },
-      })
-    )
-  ).Item;
+  const getItemCommandInput: GetItemCommandInput = {
+    TableName: tableName,
+    Key: marshall(key),
+  };
+  const item = (await client.send(new GetItemCommand(getItemCommandInput)))
+    .Item;
   if (!item) return null;
 
   /* Converting the DynamoDB record to a JavaScript object. */

--- a/src/services/compare-appian/handlers/getAppianData.ts
+++ b/src/services/compare-appian/handlers/getAppianData.ts
@@ -9,11 +9,22 @@ exports.handler = async function (
 ) {
   console.log("Received event:", JSON.stringify(event, null, 2));
   const data: Types.AppianSeatoolCompareData = { ...event.Payload };
+
+  if (!process.env.appianTableName) {
+    throw "process.env.appianTableName needs to be defined.";
+  }
   try {
     const appianRecord = await getItem({
       tableName: process.env.appianTableName,
-      id: data.id,
+      key: {
+        id: data.id,
+      },
     });
+
+    if (!appianRecord) {
+      throw "No Appian record found";
+    }
+
     data.appianRecord = appianRecord as Types.AppianRecord;
     data.SPA_ID = appianRecord.payload?.SPA_ID;
 

--- a/src/services/compare-appian/handlers/seatoolRecordExist.ts
+++ b/src/services/compare-appian/handlers/seatoolRecordExist.ts
@@ -9,10 +9,17 @@ exports.handler = async function (
   const data = { ...event.Payload, seatoolExist: false };
 
   // appian.SPA_ID should have a 1-to-1 relationship with SEATool.id
+
+  if (!process.env.seatoolTableName) {
+    throw "process.env.seatoolTableName needs to be defined.";
+  }
+
   try {
     const item = await getItem({
       tableName: process.env.seatoolTableName,
-      id: data.SPA_ID,
+      key: {
+        id: data.SPA_ID,
+      },
     });
 
     if (item) {

--- a/src/services/compare-appian/handlers/workflowStarter.ts
+++ b/src/services/compare-appian/handlers/workflowStarter.ts
@@ -11,11 +11,19 @@ exports.handler = async function (event: {
   const client = new SFNClient({ region: process.env.region });
   const id = event.Records[0].dynamodb.Keys.id.S;
 
+  if (!process.env.appianTableName) {
+    throw "process.env.appianTableName needs to be defined.";
+  }
+
   /* Retrieving the record from the DynamoDB table. */
   const appianRecord = await getItem({
     tableName: process.env.appianTableName,
-    id,
+    key: { id },
   });
+
+  if (!appianRecord) {
+    throw "No appian record found";
+  }
 
   /* Checking if the appian record was submitted within the last 200 days. */
   const submissionDate = appianRecord.payload?.SBMSSN_DATE;

--- a/src/services/compare-mmdl/handlers/compare.ts
+++ b/src/services/compare-mmdl/handlers/compare.ts
@@ -1,5 +1,6 @@
 import { has } from "lodash";
 import { trackError } from "../../../libs";
+import * as Types from "../../../types";
 
 exports.handler = async function (
   event: { Payload: any },
@@ -7,7 +8,7 @@ exports.handler = async function (
   callback: Function
 ) {
   console.log("Received event:", JSON.stringify(event, null, 2));
-  const data = { ...event.Payload, match: false };
+  const data: Types.MmdlSeatoolCompareData = { ...event.Payload, match: false };
 
   try {
     if (has(data, ["seatoolRecord", "STATE_PLAN", "SUBMISSION_DATE"])) {

--- a/src/services/compare-mmdl/handlers/getMmdlData.ts
+++ b/src/services/compare-mmdl/handlers/getMmdlData.ts
@@ -9,13 +9,22 @@ exports.handler = async function (
 ) {
   console.log("Received event:", JSON.stringify(event, null, 2));
   const data: Types.MmdlSeatoolCompareData = { ...event.Payload };
+
+  if (!process.env.mmdlTableName) {
+    throw "process.env.mmdlTableName needs to be defined.";
+  }
+
   try {
     const mmdlRecord = await getItem({
       tableName: process.env.mmdlTableName,
-      id: data.id,
+      key: {
+        PK: data.PK,
+        TN: data.TN,
+      },
     });
+
     data.mmdlRecord = mmdlRecord as Types.MmdlRecord;
-    data.transmittalNumber = mmdlRecord?.transmittalNumber;
+    data.TN = mmdlRecord?.TN;
 
     const { programType } = getMmdlProgType(mmdlRecord as Types.MmdlRecord);
     const sigInfo = getMmdlSigInfo(mmdlRecord as Types.MmdlRecord);

--- a/src/services/compare-mmdl/handlers/initStatus.ts
+++ b/src/services/compare-mmdl/handlers/initStatus.ts
@@ -1,17 +1,19 @@
 import { putItem, trackError } from "../../../libs";
+import { MmdlSeatoolCompareData } from "../../../types";
 
 exports.handler = async function (
-  event: { Context: { Execution: { Input: { id: string } } } },
+  event: { Context: { Execution: { Input: { PK: string; TN: string } } } },
   _context: any,
   callback: Function
 ) {
   console.log("Received event:", JSON.stringify(event, null, 2));
-  const id = event.Context.Execution.Input.id;
-  const data = { iterations: 0, id };
+  const { PK, TN } = event.Context.Execution.Input;
+  const data: MmdlSeatoolCompareData = { iterations: 0, PK, TN };
 
   if (!process.env.statusTableName) {
     throw "process.env.statusTableName needs to be defined.";
   }
+
   try {
     await putItem({ tableName: process.env.statusTableName, item: data });
   } catch (e) {

--- a/src/services/compare-mmdl/handlers/seatoolRecordExist.ts
+++ b/src/services/compare-mmdl/handlers/seatoolRecordExist.ts
@@ -1,4 +1,5 @@
 import { getItem, trackError } from "../../../libs";
+import * as Types from "../../../types";
 
 exports.handler = async function (
   event: { Payload: any },
@@ -6,11 +7,21 @@ exports.handler = async function (
   callback: Function
 ) {
   console.log("Received event:", JSON.stringify(event, null, 2));
-  const data = { ...event.Payload, seatoolExist: false };
+  const data: Types.MmdlSeatoolCompareData = {
+    ...event.Payload,
+    seatoolExist: false,
+  };
+
+  if (!process.env.seatoolTableName) {
+    throw "process.env.seatoolTableName needs to be defined.";
+  }
+
   try {
     const item = await getItem({
       tableName: process.env.seatoolTableName,
-      id: data.transmittalNumber, // we use the transmittal number here
+      key: {
+        id: data.TN,
+      },
     });
 
     if (item) {
@@ -18,7 +29,7 @@ exports.handler = async function (
       data.seatoolRecord = item;
     } else {
       console.log(
-        `No Seatool record found for mmdl record id: ${data.id}, tranmittalNumber: ${data.transmittalNumber}`
+        `No Seatool record found for mmdl record id: ${data.PK}, Tranmittal Number: ${data.TN}`
       );
     }
   } catch (e) {

--- a/src/services/compare-mmdl/handlers/sendNoMatchAlert.ts
+++ b/src/services/compare-mmdl/handlers/sendNoMatchAlert.ts
@@ -40,25 +40,26 @@ exports.handler = async function (
 
   const secretId = `${project}/${stage}/mmdl-alerts`;
 
-  const data = { ...event.Payload } as Types.MmdlSeatoolCompareData;
+  const data: Types.MmdlSeatoolCompareData = {
+    ...event.Payload,
+  } as Types.MmdlSeatoolCompareData;
   const isCHP = data.programType == "CHP";
-  const transmittalNumber = data.transmittalNumber;
   const secretExists = await Libs.doesSecretExist(region, secretId);
   const secSinceMmdlSigned = data.secSinceMmdlSigned || 0;
 
   // has this been signed more than five days ago - if so its urgent
   const isUrgent = secSinceMmdlSigned >= 432000; // five days
 
-  const emailContent = getEmailContent({ id: transmittalNumber, isUrgent });
+  const emailContent = getEmailContent({ id: data.TN, isUrgent });
   const emailBody = getEmailBody(emailContent);
-  const subjectText = `${transmittalNumber} - ACTION REQUIRED - No matching record in SEA Tool`;
+  const subjectText = `${data.TN} - ACTION REQUIRED - No matching record in SEA Tool`;
 
   try {
     if (!secretExists) {
       // Secret doesnt exist - this will likely be the case on ephemeral branches
 
       const params = Libs.getEmailParams({
-        id: transmittalNumber,
+        id: data.TN,
         Body: emailBody,
       });
 
@@ -69,7 +70,7 @@ exports.handler = async function (
 
       await Libs.putLogsEvent({
         type: "NOTFOUND-MMDL",
-        message: `Alert for id: ${data.id} with transmittal number: ${transmittalNumber} - TEST `,
+        message: `Alert for id: ${data.PK} with transmittal number: ${data.TN} - TEST `,
       });
     } else {
       // if secrests does exist
@@ -90,7 +91,7 @@ exports.handler = async function (
 
       const emailParams = Libs.getEmailParams({
         Body: emailBody,
-        id: transmittalNumber,
+        id: data.TN,
         CcAddresses,
         sourceEmail,
         subjectText,
@@ -101,12 +102,9 @@ exports.handler = async function (
 
       await Libs.putLogsEvent({
         type: "NOTFOUND-MMDL",
-        message: `Alert for id: ${
-          data.id
-        } with transmittal number: ${transmittalNumber} - to ${[
-          ...ToAddresses,
-          ...CcAddresses,
-        ].join(", ")}`,
+        message: `Alert for id: ${data.PK} with transmittal number: ${
+          data.TN
+        } - to ${[...ToAddresses, ...CcAddresses].join(", ")}`,
       });
     }
   } catch (e) {

--- a/src/services/compare-mmdl/handlers/updateStatus.ts
+++ b/src/services/compare-mmdl/handlers/updateStatus.ts
@@ -1,4 +1,5 @@
 import { putItem, trackError } from "../../../libs";
+import * as Types from "../../../types";
 
 exports.handler = async function (
   event: { Payload: { iterations: number } },
@@ -6,11 +7,16 @@ exports.handler = async function (
   callback: Function
 ) {
   console.log("Received event:", JSON.stringify(event, null, 2));
-  const data = { ...event.Payload, iterations: event.Payload.iterations + 1 };
+
+  const data = {
+    ...event.Payload,
+    iterations: event.Payload.iterations + 1,
+  } as Types.MmdlSeatoolCompareData;
 
   if (!process.env.statusTableName) {
     throw "process.env.statusTableName needs to be defined.";
   }
+
   try {
     await putItem({
       tableName: process.env.statusTableName,

--- a/src/services/compare-mmdl/handlers/utils/getEmailContent.ts
+++ b/src/services/compare-mmdl/handlers/utils/getEmailContent.ts
@@ -16,16 +16,16 @@ export const getEmailContent = ({
                 <center>
                 <h2>This is ${
                   isUrgent ? "an urgent" : "a"
-                } reminder that there's no matching record in SEA Tool for ${id}.</h2>
+                } reminder that there's no matching record in <a href="https://sea.cms.gov/" style="text-decoration:none" target="_blank">SEA Tool</a> for ${id}.</h2>
                 <br>
                 <p>Either a record wasn't created in SEA Tool, or the SPA ID in MMDL and SEA Tool don't match.</p>
                 ${
                   isUrgent
-                    ? "<em>Failure to address this could lead to critical delay in the review process and a deemed aproved SPA.</em>"
+                    ? "<em>Failure to address this could lead to critical delays in the review process and a deemed approved SPA or waiver action.</em>"
                     : ""
                 }
                 <br>
-                <div style=' background-color: rgb(22, 82, 150); width: 580px; padding: 20px; margin: 20px; color: white;'> if you have any questions, please contact the help desk at <a href="mailto:SEATool_helpDesk@cms.hhs.org" style="color:#ffffff;">SEATool_helpDesk@cms.hhs.org</a> </div>
+                <div style=' background-color: rgb(22, 82, 150); width: 580px; padding: 20px; margin: 20px; color: white;'> if you have any questions, please contact the help desk at <a href="mailto:SEATool_HelpDesk@cms.hhs.gov" style="color:#ffffff;">SEATool_HelpDesk@cms.hhs.gov</a> </div>
                 </center>
             </body>
         </html>

--- a/src/services/compare-mmdl/handlers/utils/getMmdlInfoFromRecord.ts
+++ b/src/services/compare-mmdl/handlers/utils/getMmdlInfoFromRecord.ts
@@ -26,7 +26,7 @@ export function getMmdlSigInfo(
     const diffInSec = (today - signedOn) / 1000; // from ms to sec we div by 1000
 
     if (diffInSec < 0) {
-      throw `Signed date is future date for MMDL record: ${mmdlRecord.id}`;
+      throw `Signed date is future date for MMDL record: ${mmdlRecord.PK}`;
     }
 
     const statuses = mmdlRecord.statuses.sort(

--- a/src/services/compare-mmdl/handlers/workflowStarter.ts
+++ b/src/services/compare-mmdl/handlers/workflowStarter.ts
@@ -6,16 +6,21 @@ import * as Types from "../../../types";
 /* This is the Lambda function that is triggered by the DynamoDB stream. It is responsible for starting
 the Step Function execution. */
 exports.handler = async function (event: {
-  Records: { dynamodb: { Keys: { id: { S: any } } } }[];
+  Records: { dynamodb: { Keys: { PK: { S: any }; TN: { S: any } } } }[];
 }) {
   console.log("Received event:", JSON.stringify(event, null, 2));
   const client = new SFNClient({ region: process.env.region });
-  const id = event.Records[0].dynamodb.Keys.id.S;
+  const PK = event.Records[0].dynamodb.Keys.PK.S;
+  const TN = event.Records[0].dynamodb.Keys.TN.S;
+
+  if (!process.env.mmdlTableName) {
+    throw "process.env.mmdlTableName needs to be defined.";
+  }
 
   /* Retrieving the record from the DynamoDB table. */
   const mmdlRecord = await getItem({
     tableName: process.env.mmdlTableName,
-    id,
+    key: { PK, TN },
   });
 
   /* A function that returns an object with the following properties:
@@ -31,10 +36,8 @@ exports.handler = async function (event: {
   ) {
     /* Creating an object that will be passed to the StartExecutionCommand. */
     const params = {
-      input: JSON.stringify({
-        id,
-      }),
-      name: id,
+      input: JSON.stringify({ TN, PK }),
+      name: `${PK}#${TN}`,
       stateMachineArn: process.env.stateMachineArn,
     };
 
@@ -54,6 +57,6 @@ exports.handler = async function (event: {
       console.log("finally");
     }
   } else {
-    console.log(`Record ${id} not signed within last 250 days. Ignoring...`);
+    console.log(`Record ${PK} not signed within last 250 days. Ignoring...`);
   }
 };

--- a/src/services/connector/handlers/sinkMmdlData.ts
+++ b/src/services/connector/handlers/sinkMmdlData.ts
@@ -17,7 +17,7 @@ async function myHandler(
     const recordKeyObject = JSON.parse(event.key) as Types.MmdlRecordKeyObject;
     const recordValueObject = JSON.parse(event.value) as Types.MmdlStreamRecord;
 
-    const id = `${recordKeyObject.STATE_CODE}-${recordKeyObject.AGGREGATED_FORM_FIELDS_WAIVER_ID}-${recordKeyObject.PROGRAM_TYPE_CODE}`;
+    const primaryKey = `${recordKeyObject.STATE_CODE}-${recordKeyObject.AGGREGATED_FORM_FIELDS_WAIVER_ID}-${recordKeyObject.PROGRAM_TYPE_CODE}`;
 
     // Typically the PROGRAM_TYPE_CODE will match this _transNbr key
     //   MAC: "mac179_transNbr",
@@ -66,8 +66,8 @@ async function myHandler(
     }
 
     const item: Types.MmdlRecord = {
-      id,
-      transmittalNumber: transmittalNumber.trim().toUpperCase(), // remove empty strings and upper case
+      PK: primaryKey,
+      TN: transmittalNumber.trim().toUpperCase(),
       ...recordValueObject.FORM_FIELDS,
       statuses: recordValueObject.APPLICATION_WORKFLOW_STATUSES,
     };

--- a/src/services/connector/handlers/sinkSeatoolData.ts
+++ b/src/services/connector/handlers/sinkSeatoolData.ts
@@ -9,10 +9,22 @@ async function myHandler(
   if (!process.env.tableName) {
     throw "process.env.tableName needs to be defined.";
   }
-  await dynamodb.putItem({
-    tableName: process.env.tableName,
-    item: { id: JSON.parse(event.key), ...JSON.parse(event.value) },
-  });
+
+  const tableName = process.env.tableName;
+  const id = JSON.parse(event.key);
+
+  // an empty string value will represent deleted records
+  if (event.value === "") {
+    await dynamodb.deleteItem({
+      tableName,
+      key: { id },
+    });
+  } else {
+    await dynamodb.putItem({
+      tableName,
+      item: { id, ...JSON.parse(event.value) },
+    });
+  }
 }
 
 exports.handler = myHandler;

--- a/src/services/connector/handlers/tests/sinkMmdlData.test.ts
+++ b/src/services/connector/handlers/tests/sinkMmdlData.test.ts
@@ -27,7 +27,7 @@ describe("mmdl sink service tests", () => {
     expect(dynamodb.putItem).toHaveBeenCalledWith({
       tableName: "mmdl-table",
       item: {
-        id: "ZZ-16358-ABP",
+        PK: "ZZ-16358-ABP",
         mac179_transNbr: {
           FIELD_CHANGE_TYPE_CODE: "MOD",
           FIELD_DESCRIPTION:
@@ -40,7 +40,7 @@ describe("mmdl sink service tests", () => {
           REVISION_ID: 30143,
         },
         statuses: undefined,
-        transmittalNumber: "FALSE",
+        TN: "FALSE",
       },
     });
   });

--- a/src/services/connector/handlers/tests/sinkSeatoolData.test.ts
+++ b/src/services/connector/handlers/tests/sinkSeatoolData.test.ts
@@ -7,6 +7,7 @@ const seaToolSink = sink as { handler: Function };
 vi.mock("../../../../libs/dynamodb-lib", () => {
   return {
     putItem: vi.fn(),
+    deleteItem: vi.fn(),
   };
 });
 
@@ -31,6 +32,28 @@ describe("SEATool sink service tests", () => {
           ID_NUMBER: "NC-11-020",
           SUBMISSION_DATE: 1311638400000,
         },
+      },
+    });
+  });
+
+  it("tests deleting an item", async () => {
+    const event = {
+      key: '"TX-23-4440"',
+      keySchemaName: null,
+      value: "",
+      valueSchemaName: null,
+      topic: "aws.ksqldb.seatool.agg.State_Plan",
+      partition: 0,
+      offset: 1114610,
+      timestamp: 1677086273242,
+      timestampTypeName: "CreateTime",
+    };
+    await seaToolSink.handler(event);
+
+    expect(dynamodb.deleteItem).toHaveBeenCalledWith({
+      tableName: "seatool-table",
+      key: {
+        id: "TX-23-4440",
       },
     });
   });

--- a/src/services/mmdl/serverless.yml
+++ b/src/services/mmdl/serverless.yml
@@ -36,11 +36,15 @@ resources:
         StreamSpecification:
           StreamViewType: NEW_AND_OLD_IMAGES
         AttributeDefinitions:
-          - AttributeName: id
-            AttributeType: S
+          - AttributeName: "PK"
+            AttributeType: "S"
+          - AttributeName: "TN"
+            AttributeType: "S"
         KeySchema:
-          - AttributeName: id
-            KeyType: HASH
+          - AttributeName: "PK"
+            KeyType: "HASH"
+          - AttributeName: "TN"
+            KeyType: "RANGE"
         BillingMode: PAY_PER_REQUEST
   Outputs:
     TableName:

--- a/src/services/status-mmdl/serverless.yml
+++ b/src/services/status-mmdl/serverless.yml
@@ -34,11 +34,15 @@ resources:
         PointInTimeRecoverySpecification:
           PointInTimeRecoveryEnabled: true
         AttributeDefinitions:
-          - AttributeName: id
-            AttributeType: S
+          - AttributeName: "PK"
+            AttributeType: "S"
+          - AttributeName: "TN"
+            AttributeType: "S"
         KeySchema:
-          - AttributeName: id
-            KeyType: HASH
+          - AttributeName: "PK"
+            KeyType: "HASH"
+          - AttributeName: "TN"
+            KeyType: "RANGE"
         BillingMode: PAY_PER_REQUEST
   Outputs:
     TableName:

--- a/src/types/mmdl/interfaces.ts
+++ b/src/types/mmdl/interfaces.ts
@@ -4,8 +4,8 @@ export interface MmdlRecord {
   hhs_transNbr?: { FIELD_PROGRAM_TYPE_CODE: string };
   stMedDirSgnDt?: { FIELD_VALUE: any };
   statuses: ApplicationWorkflowStatus[];
-  id: any;
-  transmittalNumber: string;
+  PK: string; // State-WaiverID-ProgramCode
+  TN: string; // Transmittal Number
 }
 
 export interface MmdlStreamRecord {
@@ -72,14 +72,19 @@ interface ApplicationWorkflowStatus {
 }
 
 export interface MmdlSeatoolCompareData {
-  mmdlSigned: boolean;
+  iterations?: number;
+  mmdlSigned?: boolean;
   secSinceMmdlSigned?: number;
-  mmdlSigDate?: Date;
+  seatoolSigDate?: string;
+  mmdlSigDate?: string;
   status?: number;
+  match?: boolean;
   lastStatus?: number;
-  mmdlRecord: MmdlRecord;
-  id: string;
-  transmittalNumber: string;
+  mmdlRecord?: MmdlRecord;
+  seatoolExist?: boolean;
+  seatoolRecord?: any;
+  PK: string;
+  TN: string;
   programType?: string;
   isStatusSubmitted?: boolean;
 }
@@ -94,7 +99,7 @@ export interface MmdlRecordKeyObject {
 export interface MmdlSigInfo {
   secSinceMmdlSigned?: number;
   mmdlSigned: boolean;
-  mmdlSigDate?: Date;
+  mmdlSigDate?: string;
   status?: number;
   lastStatus?: number;
 }


### PR DESCRIPTION
## Purpose

Adding transmittalNumber as sort key to mmdl /mmdl-compare table and add seatool item delete functionality

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-23096
https://qmacbis.atlassian.net/browse/OY2-23188

## Approach

Adding sort keys to mmdl table and compare-mmdl table since users can edit transmittalNumber. This will allow each iteration of a record to be unique as key = Waiver_ID#Transmittal_Number

This change adds deleteItem functionality when seatool records are removed. Event value will be "" when item is removed.

## Assorted Notes/Considerations/Learning

mmdl and compare-table in master/val will need to be destroyed and redeployed as the table schema is being changed. Will also need to reset consumer offset for mmdl topics in master/val
