### PR TITLE
feat(cloudwatch-metrics): add ecs cpu and memory alarms

### DIFF
--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -614,8 +614,17 @@ resources:
         Namespace: AWS/ECS
         MetricName: "CPUUtilization"
         Dimensions:
+          - Name: ClusterName
+            Value: !Ref KafkaConnectCluster
           - Name: ServiceName
-            Value: !Ref KafkaConnectService
+            Value:
+              !Select [
+                2,
+                !Split [
+                  "/",
+                  !Select [5, !Split [":", !Ref KafkaConnectService]],
+                ],
+              ]
         Statistic: "Average"
         Period: "300"
         EvaluationPeriods: "2"
@@ -625,7 +634,7 @@ resources:
           - ${param:alarmsTopicArn}
         OKActions:
           - ${param:alarmsTopicArn}
-    ConnectorECSMemoryAlarm:
+    KafkaConnectServiceECSMemoryAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:
         AlarmName: ${self:service}-${sls:stage}-KafkaConnectService-MemoryUtilization
@@ -633,8 +642,17 @@ resources:
         Namespace: AWS/ECS
         MetricName: "MemoryUtilization"
         Dimensions:
+          - Name: ClusterName
+            Value: !Ref KafkaConnectCluster
           - Name: ServiceName
-            Value: !Ref KafkaConnectService
+            Value:
+              !Select [
+                2,
+                !Split [
+                  "/",
+                  !Select [5, !Split [":", !Ref KafkaConnectService]],
+                ],
+              ]
         Statistic: "Average"
         Period: "300"
         EvaluationPeriods: "2"

--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -612,24 +612,17 @@ resources:
         AlarmName: ${self:service}-${sls:stage}-KafkaConnectService-CPUUtilization
         AlarmDescription: "Trigger an alarm when the CPU utilization reaches 75%"
         Namespace: AWS/ECS
-        MetricName: "CPUUtilization"
+        MetricName: CPUUtilization
         Dimensions:
           - Name: ClusterName
             Value: !Ref KafkaConnectCluster
           - Name: ServiceName
-            Value:
-              !Select [
-                2,
-                !Split [
-                  "/",
-                  !Select [5, !Split [":", !Ref KafkaConnectService]],
-                ],
-              ]
-        Statistic: "Average"
-        Period: "300"
-        EvaluationPeriods: "2"
-        Threshold: "75"
-        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+            Value: !GetAtt KafkaConnectService.Name
+        Statistic: Average
+        Period: 600
+        EvaluationPeriods: 2
+        Threshold: 75
+        ComparisonOperator: GreaterThanOrEqualToThreshold
         AlarmActions:
           - ${param:alarmsTopicArn}
         OKActions:
@@ -640,24 +633,17 @@ resources:
         AlarmName: ${self:service}-${sls:stage}-KafkaConnectService-MemoryUtilization
         AlarmDescription: "Trigger an alarm when the Memory utilization reaches 75%"
         Namespace: AWS/ECS
-        MetricName: "MemoryUtilization"
+        MetricName: MemoryUtilization
         Dimensions:
           - Name: ClusterName
             Value: !Ref KafkaConnectCluster
           - Name: ServiceName
-            Value:
-              !Select [
-                2,
-                !Split [
-                  "/",
-                  !Select [5, !Split [":", !Ref KafkaConnectService]],
-                ],
-              ]
-        Statistic: "Average"
-        Period: "300"
-        EvaluationPeriods: "2"
-        Threshold: "75"
-        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+            Value: !GetAtt KafkaConnectService.Name
+        Statistic: Average
+        Period: 60
+        EvaluationPeriods: 2
+        Threshold: 75
+        ComparisonOperator: GreaterThanOrEqualToThreshold
         AlarmActions:
           - ${param:alarmsTopicArn}
         OKActions:

--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -619,7 +619,7 @@ resources:
           - Name: ServiceName
             Value: !GetAtt KafkaConnectService.Name
         Statistic: Average
-        Period: 600
+        Period: 60
         EvaluationPeriods: 2
         Threshold: 75
         ComparisonOperator: GreaterThanOrEqualToThreshold

--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -606,6 +606,44 @@ resources:
         Period: 60
         Statistic: Sum
         Threshold: 1
+    KafkaConnectServiceECSCpuAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${sls:stage}-KafkaConnectService-CPUUtilization
+        AlarmDescription: "Trigger an alarm when the CPU utilization reaches 75%"
+        Namespace: AWS/ECS
+        MetricName: "CPUUtilization"
+        Dimensions:
+          - Name: ServiceName
+            Value: !Ref KafkaConnectService
+        Statistic: "Average"
+        Period: "300"
+        EvaluationPeriods: "2"
+        Threshold: "75"
+        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+        AlarmActions:
+          - ${param:ecsFailureTopicArn}
+        OKActions:
+          - ${param:ecsFailureTopicArn}
+    ConnectorECSMemoryAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${sls:stage}-KafkaConnectService-MemoryUtilization
+        AlarmDescription: "Trigger an alarm when the Memory utilization reaches 75%"
+        Namespace: AWS/ECS
+        MetricName: "MemoryUtilization"
+        Dimensions:
+          - Name: ServiceName
+            Value: !Ref KafkaConnectService
+        Statistic: "Average"
+        Period: "300"
+        EvaluationPeriods: "2"
+        Threshold: "75"
+        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+        AlarmActions:
+          - ${param:ecsFailureTopicArn}
+        OKActions:
+          - ${param:ecsFailureTopicArn}
     LambdaConfigureConnectorsSecurityGroup:
       Type: AWS::EC2::SecurityGroup
       Properties:

--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -622,9 +622,9 @@ resources:
         Threshold: "75"
         ComparisonOperator: "GreaterThanOrEqualToThreshold"
         AlarmActions:
-          - ${param:ecsFailureTopicArn}
+          - ${param:alarmsTopicArn}
         OKActions:
-          - ${param:ecsFailureTopicArn}
+          - ${param:alarmsTopicArn}
     ConnectorECSMemoryAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:
@@ -641,9 +641,9 @@ resources:
         Threshold: "75"
         ComparisonOperator: "GreaterThanOrEqualToThreshold"
         AlarmActions:
-          - ${param:ecsFailureTopicArn}
+          - ${param:alarmsTopicArn}
         OKActions:
-          - ${param:ecsFailureTopicArn}
+          - ${param:alarmsTopicArn}
     LambdaConfigureConnectorsSecurityGroup:
       Type: AWS::EC2::SecurityGroup
       Properties:


### PR DESCRIPTION
## Purpose

This PR is to configure CPUUtilsation and MemoryUtilisation  cloudwatch alarms for all ecs services.  The alarms is set to trigger on 75% utilisation threshold hold.  The alarms are configured to send a notification to the alerts' service SNS topic.  
#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-23316

## Approach
Alarms have been created for all ecs clusters and services running in the clusters. Memory and cpu metrics are reported out of the box by AWS. We are only creating the cloudwatch alarms to send  notifications to the alert sns topic when specific thresholds are met.

## Assorted Notes/Considerations/Learning

The configuration paramters to be set for the cloudformation template can be found here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-metrics.html#available_cloudwatch_metrics