### PR TITLE
feat(8am alerts): Add custom wait time to send alerts at 8am

### DIFF
--- a/docs/docs/services/compare-mmdl.md
+++ b/docs/docs/services/compare-mmdl.md
@@ -17,8 +17,10 @@ The basic logic of the compare service is as follows:
 
 the wokflowStarter lambda has an mmdl stream which receives all change events to the mmdl table. this function retrieves the mmdl item, uses the getMmdlInfoFromRecord util to determine if the record has been signed and if so, how long ago. If the record has not been signed yet or if its older than 250 days, the function ignores the record. Otherwise it starts the compare state machine with the record id as input.
 
-The state machine is kicked off with the initStatus function which initializes a record in the status-mmdl table.
-The service then waits for a time determined using stage params. These params use second units and are identical for higher environments but use smaller increments for default branches to allow for a more immediate feedback loop when testing.
+
+
+The state machine is kicked off with the getStartAtTimeStamp function which generates a time to start the state machine based on stage parameter. In higher environments this function will produce a timestamp of 8am EST three days following the day it was started.
+ex. a record submitted at 4pm ET on a tue will result in the state machine initializing at 8am EST on that friday. For default branches this time will be ten minutes from when submitted to allow for a more immediate feedback loop when testing.
 
 After the initialWait the mmdl record is retrieved from the mmdl dynamo table, we check to see if a seatool record exists for the same id, if one exists we compare the records to see if they were both signed on the same date, if not an email is sent to the recipients defined by the values returned from secrets manager indicating that no match has been found.
 

--- a/src/services/compare-mmdl/handlers/getStartAtTimeStamp.ts
+++ b/src/services/compare-mmdl/handlers/getStartAtTimeStamp.ts
@@ -1,0 +1,49 @@
+import { trackError } from "../../../libs";
+import * as Types from "../../../types";
+
+const getTenMinutesFromNow = () => {
+  const date = new Date();
+  const tenMinutesFromNow = new Date(date.getTime() + 600000).toISOString();
+  return tenMinutesFromNow;
+};
+
+// 8am EST three days from now
+const getTimeToStart = () => {
+  const date = new Date();
+
+  // Set the UTC Hours to 12 (8AM EST)
+  date.setUTCHours(12, 0, 0, 0);
+
+  // Add 3 days to the date
+  date.setDate(date.getDate() + 3);
+
+  const timeToStart = date.toISOString();
+  return timeToStart;
+};
+
+exports.handler = async function (
+  event: { Payload: any },
+  _context: any,
+  callback: Function
+) {
+  console.log("Received event:", JSON.stringify(event, null, 2));
+  const data: Types.MmdlReportData = { ...event.Payload };
+
+  try {
+    let timeToStart;
+
+    if (process.env.skipWait === "true") {
+      timeToStart = getTenMinutesFromNow();
+    } else {
+      timeToStart = getTimeToStart();
+    }
+
+    data.startAtTimeStamp = timeToStart;
+  } catch (e) {
+    await trackError(e);
+  } finally {
+    console.log(`Returning data `, JSON.stringify(data, null, 2));
+
+    callback(null, data);
+  }
+};

--- a/src/services/compare-mmdl/serverless.yml
+++ b/src/services/compare-mmdl/serverless.yml
@@ -85,6 +85,7 @@ params:
     workflowsStatus: ON
     seatoolSubdomain: seadev
     ignoredStates: N/A
+    skipWait: false
   val:
     initialWaitSec: 172800
     tempWaitSec: 172800
@@ -93,6 +94,7 @@ params:
     workflowsStatus: ON
     seatoolSubdomain: seaval
     ignoredStates: N/A
+    skipWait: false
   production:
     initialWaitSec: 172800
     tempWaitSec: 172800
@@ -101,6 +103,7 @@ params:
     workflowsStatus: OFF
     seatoolSubdomain: sea
     ignoredStates: ZZ,ZT
+    skipWait: false
   default:
     initialWaitSec: 300 # 5 mins
     tempWaitSec: 3600 # 1 hour
@@ -109,6 +112,7 @@ params:
     workflowsStatus: ON
     seatoolSubdomain: seadev
     ignoredStates: N/A
+    skipWait: true
 
 custom:
   project: ${env:PROJECT}
@@ -167,6 +171,11 @@ functions:
       stage: ${sls:stage}
       mmdlTableName: ${param:mmdlTableName}
       errorsTopicArn: ${param:errorsTopicArn}
+  getStartAtTimeStamp:
+    handler: handlers/getStartAtTimeStamp.handler
+    environment:
+      errorsTopicArn: ${param:errorsTopicArn}
+      skipWait: ${param:skipWait}
   stopExecutions:
     handler: handlers/stopExecutions.handler
     environment:
@@ -205,11 +214,17 @@ stepFunctions:
           - !GetAtt StateMachineLogGroup.Arn
       definition:
         Comment: "A State Machine to orchestrate a CMS alerting workflow for MMDL."
-        StartAt: InitialWait
+        StartAt: GetStartAtTimeStampTask
         States:
+          GetStartAtTimeStampTask:
+            Type: Task
+            Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-getStartAtTimeStamp"
+            Parameters:
+              Payload.$: $
+            Next: InitialWait
           InitialWait:
             Type: Wait
-            Seconds: ${param:initialWaitSec}
+            TimestampPath: $.startAtTimeStamp
             Next: GetMmdlDataTask
           GetMmdlDataTask:
             Type: Task

--- a/src/services/compare-mmdl/serverless.yml
+++ b/src/services/compare-mmdl/serverless.yml
@@ -78,7 +78,6 @@ provider:
             - !Sub "arn:aws:kms:${self:provider.region}:${AWS::AccountId}:key/*"
 params:
   master:
-    initialWaitSec: 172800 # 2 days
     tempWaitSec: 172800 # 2 days
     timeSinceClockStartChoiceSec: 345600 # 4 days
     recordAgeChoiceSec: 21686400 # 251 days
@@ -87,7 +86,6 @@ params:
     ignoredStates: N/A
     skipWait: false
   val:
-    initialWaitSec: 172800
     tempWaitSec: 172800
     timeSinceClockStartChoiceSec: 345600
     recordAgeChoiceSec: 21686400
@@ -96,7 +94,6 @@ params:
     ignoredStates: N/A
     skipWait: false
   production:
-    initialWaitSec: 172800
     tempWaitSec: 172800
     timeSinceClockStartChoiceSec: 345600
     recordAgeChoiceSec: 21686400
@@ -105,11 +102,10 @@ params:
     ignoredStates: ZZ,ZT
     skipWait: false
   default:
-    initialWaitSec: 300 # 5 mins
     tempWaitSec: 3600 # 1 hour
     timeSinceClockStartChoiceSec: 3
     recordAgeChoiceSec: 604800 # 7 days
-    workflowsStatus: ON
+    workflowsStatus: OFF
     seatoolSubdomain: seadev
     ignoredStates: N/A
     skipWait: true

--- a/src/types/mmdl/interfaces.ts
+++ b/src/types/mmdl/interfaces.ts
@@ -104,6 +104,7 @@ export interface MmdlReportData {
   mmdlSigned?: boolean;
   clockStartDate?: number; // epoch time
   secSinceClockStart?: number;
+  startAtTimeStamp?: string;
 }
 
 interface Recipients {


### PR DESCRIPTION
## Purpose

This change adds functionality to allow alerts to be sent at 8am EST

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-23318

## Approach

This replaces the initial step in the state machine definition with a custom task which provides the startAtTimeStamp variable to the initialWait choice step. The time for ephemeral branches is ten minutes from initialization. For all higher environments this time resolves to 8am EST three days from the day initialized. 

ex. a record submitted at 4pm ET on a tue will result in the state machine initializing at 8am EST on that friday.

## Assorted Notes/Considerations/Learning

N/A
